### PR TITLE
fix(#8): use clamav-debian image for ARM64/Apple Silicon support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [ClamAV®](https://www.clamav.net/) is an open-source antivirus engine for detecting trojans, viruses, malware & other malicious threats.
 
 This add-on allows you to run [ClamAV](https://www.clamav.net/) through the DDEV web service.
-The docker image used : [clamav/clamav:1.5.1](https://hub.docker.com/r/clamav/clamav).
+The Docker image used is [clamav/clamav-debian:1.5.1](https://hub.docker.com/r/clamav/clamav-debian) (multi-arch: amd64, arm64, ppc64le), so it works on Apple Silicon and other ARM64 hosts as well as x86_64.
 
 ## Getting Started
 

--- a/docker-compose.clamav.yaml
+++ b/docker-compose.clamav.yaml
@@ -2,7 +2,7 @@
 services:
   clamav:
     container_name: "ddev-${DDEV_SITENAME}-clamav"
-    image: clamav/clamav:1.5.1
+    image: clamav/clamav-debian:1.5.1
     networks: [default, ddev_default]
     volumes:
       - "../:/scandir"


### PR DESCRIPTION
## Description

Use the official multi-arch ClamAV Debian image so the add-on works on **Apple Silicon (ARM64)** and other ARM64 hosts, in addition to x86_64.

## Problem

On ARM64 (e.g. Apple Silicon Macs), `ddev restart` failed with:

> no matching manifest for linux/arm64/v8 in the manifest list entries

The Alpine-based image `clamav/clamav:1.5.1` only provides `linux/amd64` (and similar) manifests, not `linux/arm64`.

## Solution

- **Docker image:** `clamav/clamav:1.5.1` → `clamav/clamav-debian:1.5.1`
- Same ClamAV version (1.5.1), same ports (3310, 7357) and usage.
- [clamav/clamav-debian](https://hub.docker.com/r/clamav/clamav-debian) is the official multi-arch image (`linux/amd64`, `linux/arm64`, `linux/ppc64le`).

## Changes

- **docker-compose.clamav.yaml:** use `clamav/clamav-debian:1.5.1` and add a short comment about ARM64.
- **README.md:** document the Debian image and multi-arch (incl. Apple Silicon) support.

## Testing

- [x] `ddev restart` succeeds on Apple Silicon (ARM64).
- [x] `ddev restart` still works on amd64 (e.g. Intel/AMD).

Fixes #8
